### PR TITLE
fix(index): Skip the translation ID in case of interpolation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,6 +148,13 @@ var extractor
 
           // Store the translationKey with the value into results
           var defaultValueByTranslationKey = function (translationKey, translationDefaultValue) {
+            // Interpolated translationKey
+            if (_.startsWith(translationKey, interpolation.startDelimiter) &&
+              _.endsWith(translationKey, interpolation.endDelimiter) &&
+              !(translationKey.split(interpolation.endDelimiter).length -2)) {
+              return
+            }
+
             if (regexName !== "JavascriptServiceArraySimpleQuote" &&
               regexName !== "JavascriptServiceArrayDoubleQuote") {
               if (keyAsText === true && translationDefaultValue.length === 0) {


### PR DESCRIPTION
Handle the case of interpolating the translation ID inside a directive

It fixes:
Boulangerie/angular-translate-extract#9
angular-translate/grunt-angular-translate#72