### PR TITLE
Add html parsing on Cheerio

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ WIP!
 Options src and jsonSrc may be specified according to the grunt Configuring tasks guide.
 
 - [src](#src)
+- [htmlSrc](#htmlSrc)
 - [nullEmpty](#nullempty-v026)
 - [namespace](#namespace-v026)
 - [interpolation](#interpolation)
@@ -116,9 +117,20 @@ Options src and jsonSrc may be specified according to the grunt Configuring task
 Type: `Array`
 Default: `undefined`
 
-Example: `[ 'src/**/*.js' ]`
+Example: `[ 'src/**/*.js', 'src/**/*.html' ]`
 
 Define a file list to parse for extract translation.
+
+#### htmlSrc
+
+Type: `Array`
+Default: `undefined`
+
+Example: `[ 'src/**/*.html' ]`
+
+Define a file list to parse with [cheerio](https://github.com/cheeriojs/cheerio).
+
+There **translate** and **translate-attr** directives with nested html are supported.
 
 #### nullEmpty (v0.2.6)
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   ],
   "readmeFilename": "README.md",
   "dependencies": {
+    "cheerio": "^1.0.0-rc.2",
     "flat": "^1.2.0",
     "glob-expand": "0.1.0",
     "json-stable-stringify": "^1.0.0",


### PR DESCRIPTION
Add htmlSrc option to parse with [cheerio](https://github.com/cheeriojs/cheerio) for support nested html in translate and translate-attr directives.
For example:
```
<p translate="section.hint">
    <em>Word order</em>
    <a href="https://www.google.com/search?q='word+order+matters'">matters</a>.
</p>
<input type="text" class="form-control" id="mynameId" name="myname"
    translate-attr="{placeholder: 'section.placeholderMyname', title: 'section.titleMyname'}"
    placeholder="Name" title="Edit Name"
    ng-model="vm.myname" ng-required="true"
/>
```